### PR TITLE
experimental onAttrChanged method

### DIFF
--- a/src/tram-lite.js
+++ b/src/tram-lite.js
@@ -222,9 +222,24 @@ function TramLite() {
 		return elements;
 	}
 
+	/**
+	 * helper function to setup a mutation observer, and trigger a callback on attribute changes
+	 */
+	function onAttrChanged(element, callback) {
+		const observer = new MutationObserver((mutations) => {
+			mutations.forEach((mutation) => {
+				callback(mutation);
+			});
+		});
+
+		observer.observe(element, {
+			attributes: true,
+		});
+	}
+
 	// expose the html and define functions
 	// all other functions are internal, and not meant to be exposed
-	return { html, define, queryAllDOM };
+	return { html, define, onAttrChanged, queryAllDOM };
 }
 
-const { html, define, queryAllDOM } = TramLite();
+const { html, define, queryAllDOM, onAttrChanged } = TramLite();


### PR DESCRIPTION
## Summary

**This is in need of an example that can't be trivially solved with existing APIs.**

New method - `onAttrChanged`.

The idea here is that currently there's no easy way to add functionality (beyond template changes) when an attribute on the component changes. While native web-components offer hooks here (with `attributeChangedCallback`), there's no way to tie into that function with tram-lite defined components.

`onAttrChanged` sets up a mutation observer, and allows us to basically get that functionality, for both tram-lite components, and other native components.

