### PR TITLE
Correct misspelling of definition in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ simple native web-applications easier and more elegant!
 <script src="https://unpkg.com/tram-lite@3"></script>
 
 <!-- define a new web-component -->
-<template is="component-defintion">
+<template is="component-definition">
 	<custom-title color="blue">
 		<!-- components have encapsulated styles -->
 		<style>

--- a/docs/pages/about.html
+++ b/docs/pages/about.html
@@ -10,7 +10,7 @@
 <script src="https://unpkg.com/tram-lite@3"></script>
 
 <!-- define a new web-component, custom-title -->
-<template is="component-defintion">
+<template is="component-definition">
 	<custom-title color="blue">
 		<!-- web-components have encapsulated styles -->
 		<style>

--- a/src/ComponentDefinition.js
+++ b/src/ComponentDefinition.js
@@ -65,7 +65,7 @@ class ComponentDefinition extends HTMLTemplateElement {
 }
 
 // associate this class as a custom built-in for the template tag
-// e.g. it can be created with a <template is="component-defintion"> tag in HTML
+// e.g. it can be created with a <template is="component-definition"> tag in HTML
 customElements.define('component-definition', ComponentDefinition, { extends: 'template' });
 
 try {


### PR DESCRIPTION
## Summary

Fixes #21 and corrects a misspelling of "definition" in 3 places.

## Checklist
- [ ] PR Summary
- [ ] PR Annotations
- [ ] Tests
- [ ] Version Bump
