### PR TITLE
guide-building-components.html fix bad attribute on x-progressbar definition

### DIFF
--- a/docs/pages/guide-building-components.html
+++ b/docs/pages/guide-building-components.html
@@ -128,7 +128,7 @@
 	<code-template-html>
 		<template>
 			<template tl-definition>
-				<x-progressbar value="5">
+				<x-progressbar fill="5">
 					<progress value="${'fill'}" max="10"></progress>
 					<span>${'fill'}/10</span>
 					<input type="number" tl-controlled tl-hostattr="fill" />

--- a/docs/pages/guide-building-components.html
+++ b/docs/pages/guide-building-components.html
@@ -153,7 +153,7 @@
 	<code-template-html>
 		<template>
 			<template tl-definition>
-				<x-progressbar value="5">
+				<x-progressbar fill="5">
 					<progress value="${'fill'}" max="10"></progress>
 					<span>${'fill'}/10</span>
 					<input type="number" tl-controlled tl-hostattr="fill" />


### PR DESCRIPTION
## Summary

The attribute specified is value, but it's supposed to be fill. I assume a think.

Example only cnage. No need for tests or version bump.

## Checklist
- [x] PR Summary
- [x] PR Annotations
- [ ] Tests
- [ ] Version Bump
