### PR TITLE
Changed to dark mode default

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
 
 		<!-- open props -->
 		<link rel="stylesheet" href="https://unpkg.com/open-props" />
-		<link rel="stylesheet" href="https://unpkg.com/open-props/normalize.min.css" />
+		<link rel="stylesheet" href="https://unpkg.com/open-props/normalize.dark.min.css" />
 
 		<!-- Title -->
 		<title>Tram-Lite</title>


### PR DESCRIPTION
## Summary
If the system's light mode is on, open-props will use a light css as a default.
Setting the min file to use only the dark mode solves this.

## Checklist
- [ ] PR Summary
- [ ] PR Annotations
- [ ] Tests
- [ ] Version Bump

Note the Text Font Colors
Before:
<img width="1470" alt="BeforeDarkMode" src="https://github.com/Tram-One/tram-lite/assets/4218148/0224f2bf-41b8-42fa-9337-d610b461a33e">
After:
<img width="1470" alt="AfterDarkMode" src="https://github.com/Tram-One/tram-lite/assets/4218148/ad619edb-914c-485b-a50b-b517fb244c20">

