### PR TITLE
tl-provider and tl-context components

### DIFF
--- a/build.js
+++ b/build.js
@@ -31,6 +31,7 @@ const classFiles = [
 	'src/processors/ControlledInput.js',
 	'src/processors/AttrBroadcaster.js',
 	'src/processors/EventRebroadcaster.js',
+	'src/processors/ContextConsumer.js',
 	'src/ComponentDefinition.js',
 ];
 const loadedClassFiles = Object.fromEntries(

--- a/docs/index.html
+++ b/docs/index.html
@@ -94,6 +94,7 @@
 				<a href="#tl-definition"><code>tl-definition</code></a>
 				<a href="#tl-controlled"><code>tl-controlled</code></a>
 				<a href="#tl-effect"><code>tl-effect</code></a>
+				<a href="#tl-context"><code>tl-context</code></a>
 				<a href="#tl-broadcast"><code>tl-broadcast</code></a>
 				<a href="#tl-rebroadcast"><code>tl-rebroadcast</code></a>
 			</side-nav-section>
@@ -117,6 +118,7 @@
 			<page id="tl-rebroadcast"><html-import src="./pages/html-tl-rebroadcast.html"></html-import></page>
 			<page id="tl-controlled"><html-import src="./pages/html-tl-controlled.html"></html-import></page>
 			<page id="tl-effect"><html-import src="./pages/html-tl-effect.html"></html-import></page>
+			<page id="tl-context"><html-import src="./pages/html-tl-context.html"></html-import></page>
 			<page id="define"><html-import src="./pages/js-define.html"></html-import></page>
 			<page id="addAttributeListener"><html-import src="./pages/js-addAttributeListener.html"></html-import></page>
 			<page id="broadcastEvent"><html-import src="./pages/js-broadcastEvent.html"></html-import></page>
@@ -130,15 +132,5 @@
 			<page id="migration-guide"><html-import src="./pages/migration-guide.html"></html-import></page>
 			<page id="micro-guide"><html-import src="./pages/micro-guide.html"></html-import></page>
 		</main>
-
-		<script>
-			// because of a lack of :has pseudo-selector support, sometimes we can end up with the main page having no content!
-			// for now, we'll always redirect to the about page, but once we have that :has support, we can remove this
-			document.addEventListener('DOMContentLoaded', function (event) {
-				if (!window.location.hash) {
-					window.location.hash = 'about';
-				}
-			});
-		</script>
 	</body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -95,6 +95,7 @@
 				<a href="#tl-controlled"><code>tl-controlled</code></a>
 				<a href="#tl-effect"><code>tl-effect</code></a>
 				<a href="#tl-context"><code>tl-context</code></a>
+				<a href="#tl-provider"><code>tl-provider</code></a>
 				<a href="#tl-broadcast"><code>tl-broadcast</code></a>
 				<a href="#tl-rebroadcast"><code>tl-rebroadcast</code></a>
 			</side-nav-section>
@@ -119,6 +120,7 @@
 			<page id="tl-controlled"><html-import src="./pages/html-tl-controlled.html"></html-import></page>
 			<page id="tl-effect"><html-import src="./pages/html-tl-effect.html"></html-import></page>
 			<page id="tl-context"><html-import src="./pages/html-tl-context.html"></html-import></page>
+			<page id="tl-provider"><html-import src="./pages/html-tl-provider.html"></html-import></page>
 			<page id="define"><html-import src="./pages/js-define.html"></html-import></page>
 			<page id="addAttributeListener"><html-import src="./pages/js-addAttributeListener.html"></html-import></page>
 			<page id="broadcastEvent"><html-import src="./pages/js-broadcastEvent.html"></html-import></page>

--- a/docs/pages/about.html
+++ b/docs/pages/about.html
@@ -58,14 +58,33 @@
 	</dt>
 	<dd><p>Attribute for building attribute driven side-effects in web-components.</p></dd>
 	<dt>
-		<a href="#tl-broadcast"><code>tl-broadcast</code></a>
-	</dt>
-	<dd><p>Custom Element for emitting events when an attribute updates in a web-component.</p></dd>
-	<dt>
 		<a href="#tl-rebroadcast"><code>tl-rebroadcast</code></a>
 	</dt>
 	<dd><p>Attribute for emitting events when another event is triggered on an element.</p></dd>
 </dl>
+<p>
+	Additionally, Tram-Lite also has a set of custom elements that can be used in web components to enhance their
+	behavior.
+	<dt>
+		<a href="#tl-broadcast"><code>tl-broadcast</code></a>
+	</dt>
+	<dd><p>Custom Element for emitting events when an attribute updates in a web-component.</p></dd>
+	<dt>
+		<a href="#tl-context"><code>tl-context</code></a>
+	</dt>
+	<dd>
+		<p>Custom Element for pulling state down from a <tag-code tag="tl-provider"></tag-code>.</p>
+	</dd>
+	<dt>
+		<a href="#tl-provider"><code>tl-provider</code></a>
+	</dt>
+	<dd>
+		<p>
+			Custom Element (can live in the shadow or light DOM), that can provide state to web-components with a
+			<tag-code tag="tl-context"></tag-code> element.
+		</p>
+	</dd>
+</p>
 
 <h2>Javascript API</h2>
 <dl>

--- a/docs/pages/html-tl-broadcast.html
+++ b/docs/pages/html-tl-broadcast.html
@@ -1,8 +1,8 @@
 <h2><code>tl-broadcast</code></h2>
 <section>
 	<p>
-		<code>tl-broadcast</code> is a custom element that lets you dispatch events up or down the tree when a
-		web-component's attributes update.
+		<tag-code tag="tl-broadcast"></tag-code> is a custom element that lets you dispatch events up or down the tree when
+		a web-component's attributes update.
 	</p>
 	<p>
 		<code-template-html>

--- a/docs/pages/html-tl-context.html
+++ b/docs/pages/html-tl-context.html
@@ -1,0 +1,117 @@
+<h2><code>tl-context</code></h2>
+<section>
+	<p>
+		<tag-code tag="tl-context"></tag-code> is a custom element that lets you retrieve and write state to a
+		<tag-code tag="tl-provider"></tag-code> parent element. The main purpose is to share state across multiple
+		components without depending on prop-drilling or sending state via events.
+	</p>
+	<p>
+		<code-template-html>
+			<template>
+				<!-- component definition -->
+				<template tl-definition>
+					<text-preview>
+						<tl-context tl-name="font-size"></tl-context>
+						<div style="font-size: ${'size'}">
+							<slot></slot>
+						</div>
+					</text-preview>
+				</template>
+
+				<!-- in the HTML Template -->
+				<tl-provider tl-name="font-size" size="1em">
+					<text-preview>This is some text content</text-preview>
+				</tl-provider>
+			</template>
+		</code-template-html>
+	</p>
+</section>
+<section>
+	<h2>Syntax</h2>
+	<p>
+		<code-template-html>
+			<template>
+				<tl-context tl-name="provider-name" tl-attrmap="provider-attribute:host-attribute"></tl-context>
+			</template>
+		</code-template-html>
+	</p>
+	<h3>Parameters</h3>
+	<dl>
+		<dt><code>tl-name</code></dt>
+		<dd>
+			<p>The name of the provider to pull context values from.</p>
+		</dd>
+		<dt><code>tl-attrmap</code> <optional-badge>optional</optional-badge></dt>
+		<dd>
+			<p>
+				Mapping of provider element's state (<code>provider-attribute</code>) to an attribute name that will be on the
+				host web-component (<code>host-attribute</code>), defaults to all the user-defined attributes on the provider
+				mapped to their same name. Can be multiple values (space delimited).
+			</p>
+		</dd>
+	</dl>
+</section>
+<section>
+	<h2>Custom Web Components</h2>
+	<p>
+		If you'd like to use this api with components that aren't defined in Tram-Lite, you can use the Javascript API to
+		apply it to a class using <code>TramLite.appendShadowRootProcessor</code>
+
+		<code-template-html>
+			<template>
+				<script src="https://unpkg.com/tram-lite@5"></script>
+				<script>
+					TramLite.appendShadowRootProcessor('tl-context', ContextConsumer, MyWebComponentClass);
+				</script>
+			</template>
+		</code-template-html>
+	</p>
+</section>
+<section>
+	<h2>Live Example</h2>
+	<div
+		class="codepen"
+		data-height="300"
+		data-theme-id="dark"
+		data-default-tab="html,result"
+		data-editable="true"
+		data-prefill="{}"
+	>
+		<pre data-lang="html">
+&lt;script src="https://unpkg.com/tram-lite@5">&lt;/script>
+
+&lt;!-- component definitions -->
+&lt;template tl-definition>
+
+  &lt;!-- example component definition -->
+  &lt;font-toggle>
+    &lt;tl-context tl-name="font-size">&lt;/tl-context>
+    &lt;label>
+      Font Size
+      &lt;select tl-controlled tl-attrmap="value:size">
+        &lt;option value="0.8em">Small&lt;/option>
+        &lt;option value="1em">Medium&lt;/option>
+        &lt;option value="1.2em">Large&lt;/option>
+      &lt;/select>
+    &lt;/label>
+  &lt;/font-toggle>
+
+  &lt;text-preview>
+    &lt;tl-context tl-name="font-size">&lt;/tl-context>
+    &lt;div style="font-size: ${'size'}">
+      &lt;slot>&lt;/slot>
+    &lt;/div>
+  &lt;/text-preview>
+
+&lt;/template>
+
+&lt;!-- HTML Page -->
+&lt;tl-provider tl-name="font-size" size="1em">
+  &lt;font-toggle>&lt;/font-toggle>
+  &lt;text-preview>This is a text preview&lt;/text-preview>
+&lt;/tl-provider></pre
+		>
+	</div>
+
+	<script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
+</section>

--- a/docs/pages/html-tl-context.html
+++ b/docs/pages/html-tl-context.html
@@ -1,9 +1,9 @@
 <h2><code>tl-context</code></h2>
 <section>
 	<p>
-		<tag-code tag="tl-context"></tag-code> is a custom element that lets you retrieve and write state to a
-		<tag-code tag="tl-provider"></tag-code> parent element. The main purpose is to share state across multiple
-		components without depending on prop-drilling or sending state via events.
+		<tag-code tag="tl-context"></tag-code> is a custom element that pulls the attributes from a
+		<tag-code tag="tl-provider"></tag-code> parent, and maps it to attributes in your web-component. The main purpose is
+		to share state across multiple components without depending on prop-drilling or sending state via events.
 	</p>
 	<p>
 		<code-template-html>
@@ -18,7 +18,7 @@
 					</text-preview>
 				</template>
 
-				<!-- in the HTML Template -->
+				<!-- main HTML -->
 				<tl-provider tl-name="font-size" size="1em">
 					<text-preview>This is some text content</text-preview>
 				</tl-provider>

--- a/docs/pages/html-tl-controlled.html
+++ b/docs/pages/html-tl-controlled.html
@@ -22,7 +22,7 @@
 	<p>
 		<code-template-html>
 			<template>
-				<input tl-controlled tl-attrmap="attribute:reference" tl-trigger="eventName" />
+				<input tl-controlled tl-attrmap="input-attribute:host-attribute" tl-trigger="eventName" />
 			</template>
 		</code-template-html>
 	</p>
@@ -31,9 +31,9 @@
 		<dt><code>tl-attrmap</code> <optional-badge>optional</optional-badge></dt>
 		<dd>
 			<p>
-				Mapping of target element's state (<code>attribute</code>) to an attribute name that will be on the host
-				web-component (<code>reference</code>), defaults to <code>"value:value"</code>. Can be multiple values (space
-				delimited).
+				Mapping of input element's state (<code>input-attribute</code>) to an attribute name that will be on the host
+				web-component (<code>host-attribute</code>), defaults to <code>"value:value"</code>. Can be multiple values
+				(space delimited).
 			</p>
 		</dd>
 		<dt><code>tl-trigger</code> <optional-badge>optional</optional-badge></dt>

--- a/docs/pages/html-tl-provider.html
+++ b/docs/pages/html-tl-provider.html
@@ -1,0 +1,32 @@
+<h2><code>tl-provider</code></h2>
+<section>
+	<p>
+		<tag-code tag="tl-provider"></tag-code> is a custom Element that can provide state to multiple
+		<tag-code tag="tl-context"></tag-code> elements. <tag-code tag="tl-provider"></tag-code> can live in the shadow or
+		light DOM.
+	</p>
+</section>
+<section>
+	<h2>Syntax</h2>
+	<p>
+		<code-template-html>
+			<template>
+				<tl-provider tl-name="provider-name" custom-attributes></tl-provider>
+			</template>
+		</code-template-html>
+	</p>
+	<h3>Parameters</h3>
+	<dl>
+		<dt><code>tl-name</code></dt>
+		<dd>
+			<p>Name to match with <tag-code tag="tl-context"></tag-code> tag.</p>
+		</dd>
+		<dt><code>custom-attributes</code> <optional-badge>optional</optional-badge></dt>
+		<dd>
+			<p>
+				User defined attributes to make available to components that use <tag-code tag="tl-context"></tag-code>. Can be
+				boolean or string values. No specific prefix is required.
+			</p>
+		</dd>
+	</dl>
+</section>

--- a/examples/inline/index.html
+++ b/examples/inline/index.html
@@ -281,6 +281,31 @@
 					}
 				</script>
 			</in-progressbar>
+
+			<in-start-color-setter>
+				<tl-context tl-name="color-theme" tl-attrmap="start-color:color"></tl-context>
+				<input type="color" tl-controlled tl-attrmap="value:color" tl-trigger="input" />
+			</in-start-color-setter>
+			<in-end-color-setter>
+				<tl-context tl-name="color-theme" tl-attrmap="end-color:color"></tl-context>
+				<input type="color" tl-controlled tl-attrmap="value:color" tl-trigger="input" />
+			</in-end-color-setter>
+			<in-color-preview>
+				<tl-context tl-name="color-theme"></tl-context>
+				<style>
+					div {
+						width: 120px;
+						height: 60px;
+						margin: 5px;
+						background: linear-gradient(${'degrees'}deg, ${'start-color'}, ${'end-color'});
+					}
+				</style>
+				<div></div>
+			</in-color-preview>
+			<in-direction-setter>
+				<tl-context tl-name="color-theme"></tl-context>
+				<input type="range" min="0" max="360" tl-controlled tl-attrmap="value:degrees" tl-trigger="input" />
+			</in-direction-setter>
 		</template>
 
 		<in-title>Tram-Lite Components!</in-title>
@@ -305,6 +330,14 @@
 		</in-container>
 		<in-container name="Progress Bar">
 			<in-progressbar></in-progressbar>
+		</in-container>
+		<in-container name="Gradient Builder">
+			<tl-provider tl-name="color-theme" start-color="#E66465" end-color="#9198E5" degrees="0">
+				<in-start-color-setter></in-start-color-setter>
+				<in-end-color-setter></in-end-color-setter>
+				<in-direction-setter></in-direction-setter>
+				<in-color-preview></in-color-preview>
+			</tl-provider>
 		</in-container>
 	</body>
 </html>

--- a/examples/inline/inline.cy.js
+++ b/examples/inline/inline.cy.js
@@ -86,5 +86,25 @@ describe('Tram-Lite Example Components', () => {
 		cy.get('in-progressbar').should('have.attr', 'warning');
 		cy.get('in-progressbar').find('input#max').clear().type('15');
 		cy.get('in-progressbar').should('not.have.attr', 'warning');
+
+		/* verify that components pull initial state from providers */
+		cy.get('tl-provider[tl-name="color-theme"]').find('in-start-color-setter').should('have.attr', 'color', '#E66465');
+		cy.get('tl-provider[tl-name="color-theme"]').find('in-end-color-setter').should('have.attr', 'color', '#9198E5');
+		cy.get('tl-provider[tl-name="color-theme"]').find('in-direction-setter').should('have.attr', 'degrees', '0');
+		cy.get('tl-provider[tl-name="color-theme"]')
+			.find('in-color-preview')
+			.should('have.attr', 'start-color', '#E66465')
+			.should('have.attr', 'end-color', '#9198E5')
+			.should('have.attr', 'degrees', '0');
+
+		/* verify that components update when provider state updates */
+		cy.get('tl-provider[tl-name="color-theme"]').invoke('attr', 'degrees', '45');
+		cy.get('tl-provider[tl-name="color-theme"]').find('in-direction-setter').should('have.attr', 'degrees', '45');
+		cy.get('tl-provider[tl-name="color-theme"]').find('in-color-preview').should('have.attr', 'degrees', '45');
+
+		/* verify that provider updates when component (with context) updates */
+		cy.get('tl-provider[tl-name="color-theme"]').find('in-direction-setter').invoke('attr', 'degrees', '90');
+		cy.get('tl-provider[tl-name="color-theme"]').should('have.attr', 'degrees', '90');
+		cy.get('tl-provider[tl-name="color-theme"]').find('in-color-preview').should('have.attr', 'degrees', '90');
 	});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tram-lite",
-	"version": "5.0.0",
+	"version": "5.1.0-beta.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tram-lite",
-			"version": "5.0.0",
+			"version": "5.1.0-beta.1",
 			"license": "MIT",
 			"devDependencies": {
 				"cypress": "^12.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tram-lite",
-	"version": "5.1.0-beta.1",
+	"version": "5.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tram-lite",
-			"version": "5.1.0-beta.1",
+			"version": "5.1.0",
 			"license": "MIT",
 			"devDependencies": {
 				"cypress": "^12.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tram-lite",
-	"version": "5.1.0-beta.1",
+	"version": "5.1.0",
 	"description": "💡 HTML library for building and enhancing web-components",
 	"homepage": "https://tram-one.io/tram-lite/",
 	"repository": "https://github.com/Tram-One/tram-lite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tram-lite",
-	"version": "5.0.0",
+	"version": "5.1.0-beta.1",
 	"description": "💡 HTML library for building and enhancing web-components",
 	"homepage": "https://tram-one.io/tram-lite/",
 	"repository": "https://github.com/Tram-One/tram-lite",

--- a/src/ComponentDefinition.js
+++ b/src/ComponentDefinition.js
@@ -10,7 +10,7 @@ class ComponentDefinition {
 
 	/**
 	 * function to test if node has an attribute value with a template variable
-	 * e.g. <custom-element style="color: ${'color'}">
+	 * e.g. \<custom-element style="color: ${'color'}"\>
 	 */
 	static nodeHasTramLiteAttr = (node) =>
 		[...node.attributes].some((attr) => attr.value.match(ComponentDefinition.templateVariableRegex))
@@ -19,7 +19,7 @@ class ComponentDefinition {
 
 	/**
 	 * function to test if node has an TEXT node with a template variable
-	 * e.g. <custom-element>Hello ${'name'}</custom-element>
+	 * e.g. \<custom-element\>Hello ${'name'}\</custom-element\>
 	 */
 	static nodeHasTextElementWithTramLiteAttr = (node) =>
 		node.textContent.match(ComponentDefinition.templateVariableRegex)

--- a/src/processors/ContextConsumer.js
+++ b/src/processors/ContextConsumer.js
@@ -1,11 +1,13 @@
 /**
- * TBA
+ * ContextConsumer is a class that extends the tl-context custom element, which allows developers
+ * to share state across multiple components under a tl-provider element.
  *
  * {@link https://tram-one.io/tram-lite/#tl-context}
  */
 class ContextConsumer {
 	/**
-	 * TBA
+	 * connect function for ContextConsumer - when this is attached to an element, we
+	 *   set up a binding of attributes on the Provider and the host web-component.
 	 * @param {HTMLElement} newNode
 	 */
 	static connect(newNode) {

--- a/src/processors/ContextConsumer.js
+++ b/src/processors/ContextConsumer.js
@@ -1,0 +1,94 @@
+/**
+ * TBA
+ *
+ * {@link https://tram-one.io/tram-lite/#tl-context}
+ */
+class ContextConsumer {
+	/**
+	 * TBA
+	 * @param {HTMLElement} newNode
+	 */
+	static connect(newNode) {
+		// attributes that control the behavior of the context consumer
+		// tl-name determines the provider we should look up
+		const contextName = newNode.getAttribute('tl-name');
+		// tl-attrmap is a mapping of the provider's attributes to this one
+		// (by default, this will be a mapping of all the attributes in the provider as the same name)
+		const attributeMapString = newNode.getAttribute('tl-attrmap');
+
+		const hostElement = newNode.getRootNode().host;
+
+		// search up the tree for a context provider
+		// we do this by attaching an event listener to the top-level html element,
+		//   emitting an event from our host element, and then checking the composed path
+		//   for the first provider that matches our tl-name
+		function handleContextSearch(event) {
+			// composedPath will be a list of elements, starting with this one, and going up to the window
+			const composedPath = event.composedPath();
+			const providerElement = composedPath.find(
+				(element) => element.matches && element.matches(`tl-provider[tl-name="${contextName}"]`),
+			);
+
+			// if we can't find a provider, bail
+			if (providerElement === undefined) {
+				return;
+			}
+
+			// build a default attribute map based on all the attributes on the provider
+			const defaultAttributeMap = [...providerElement.attributes]
+				.filter((attr) => !attr.name.match(/tl-/)) // filter out tl- attributes
+				.map((attr) => `${attr.name}:${attr.name}`)
+				.join(' ');
+
+			const attributeMaps = (attributeMapString || defaultAttributeMap).split(' ');
+
+			attributeMaps.forEach((attributeMap) => {
+				const [providerAttrName, hostAttrName] = attributeMap.split(':');
+
+				// note the type of the attribute we are tracking
+				// (if it is a boolean, we'll just check if this has an attribute)
+				const attributeType = typeof providerElement[providerAttrName];
+				const isBooleanAttr = attributeType === 'boolean';
+
+				// set the value of the host based on the provider
+				hostElement.setAttribute(
+					hostAttrName,
+					isBooleanAttr
+						? providerElement.hasAttribute(providerAttrName)
+						: providerElement.getAttribute(providerAttrName),
+				);
+
+				// update the host whenever the provider attribute updates
+				TramLite.addAttributeListener(providerElement, [providerAttrName], () => {
+					hostElement.setAttribute(
+						hostAttrName,
+						isBooleanAttr
+							? providerElement.hasAttribute(providerAttrName)
+							: providerElement.getAttribute(providerAttrName),
+					);
+				});
+
+				// update the provider whenever the host attribute updates
+				TramLite.addAttributeListener(hostElement, [hostAttrName], () => {
+					providerElement.setAttribute(
+						providerAttrName,
+						isBooleanAttr ? hostElement.hasAttribute(hostAttrName) : hostElement.getAttribute(hostAttrName),
+					);
+				});
+			});
+		}
+
+		// set up the event listener on the top-most context - set it to only trigger once
+		window.addEventListener('context-search', handleContextSearch, { once: true });
+
+		// dispatch the event from this host all the way up
+		const searchEvent = new CustomEvent('context-search', {
+			bubbles: true,
+			composed: true,
+		});
+		hostElement.dispatchEvent(searchEvent);
+	}
+}
+
+// setup shadow root processor so that tl-context that are added are processed correctly
+TramLite.appendShadowRootProcessor('tl-context', ContextConsumer);


### PR DESCRIPTION
## Summary

This PR adds support for two new components, `<tl-provider>` and `<tl-context>`.
Together, these enable sharing state across multiple components without having to drill props down, or emitting events with state.

The general pattern for these elements is the following:
* `<tl-provider>` as a parent element (in the light or shadow DOM)
* `<tl-context>` in the component definition

For example:
`index.html`
```html
<tl-provider tl-name="font-size" size="1em">
  <text-preview>This is some text content</text-preview>
</tl-provider>
```

Where `<text-preview>` is a web-component that has a `<tl-context>`
```html
<!-- component definition -->
<text-preview>
  <tl-context tl-name="font-size">
  <div style="font-size: ${'size'}">
    <slot></slot>
  </div>
</text-preview>
```

The `<tl-context>` puts all user-defined attributes from the `<tl-provider>` (whose name matches) on the host component. In this case, the `size` attribute on the `<tl-provider>` is copied to our `<text-preview>`, and can be used for templates, effects, or controlled inputs.

## Live Example

This is available under 5.1.0-beta.1 (or tram-lite@beta)
Codepen - https://codepen.io/JRJurman/pen/yLwyYgR

## API

For `<tl-provider>`, there is only one required attribute:
* `tl-name` - string that any `<tl-context>` element can use to associate with

Any other user-defined attributes will become possible values to include on defined web-components.

For `<tl-context>` there are a few attributes:
* `tl-name` - string that tells the context element what provider it should be pulling attributes from
* `tl-attrmap` - string, similar to `tl-controlled`'s `tl-attrmap`, this is a space delimited list of attribute mappings from the provider to the host component. By default, it is all user-defined attributes. The purpose of defining this mapping is if you want to rename the attributes, or wanted only certain attributes on the host element. 

## Meta Notes

`<tl-provider>` doesn't actually have any special logic, it is just the tag that we look for when `<tl-context>` is mounted. 

## Open Questions

### `tl-name` attribute name
`tl-name` is the attribute the associated the context and provider with each other. It's not obvious what future cases we might want `tl-name` for, so something generic here could end up painting us in a corner (not that we couldn't do a major breaking change here). We could use something more specific to this use case, like `tl-provider` or `tl-context` (which could feel redundant or confusing with the tag name). Open to other options here.

### `<tl-provider>` as a tag, or as an attribute
Technically, since `<tl-provider>` is only used as part of a query (it's not actually a web-component in the traditional sense), we could just have an attribute instead. Users could use whatever element they want, however being prescriptive here might be good for having a baseline of what components to use.
 
### Order of `tl-attrmap`
`tl-attrmap` is now used for both `tl-controlled` and `tl-context`. In the `tl-controlled` case, the ordering is `target:host` (target being an `<input>` element, and host being the web-component). Right now, the `tl-context` is mapped as `provider:host`, because that keeps the host mapping consistently at the end. We could reverse this, if we wanted the ordering to be symbolic of the tree structure (given that providers are higher in the tree).

## Checklist
- [x] PR Summary
- [x] PR Annotations
- [x] Update Docs
- [x] Tests
- [ ] Version Bump
